### PR TITLE
Add §11 "Beyond money — the post-money enterprise" + headline fact-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For "where do I add X?" see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Data currency
 
-Last refresh: **2026-07-26**. Headline vintages currently in use:
+Last refresh: **2026-08-13**. Headline vintages currently in use:
 
 | Figure | Value | Year | Source |
 |---|---|---|---|

--- a/data/essentials.json
+++ b/data/essentials.json
@@ -227,20 +227,20 @@
     "note": "The 'zero-dose' population — never received any routine immunization. Concentrated in conflict and fragile-state contexts."
   },
   "safely_managed_sanitation_share":   {
-    "value": 0.57,
+    "value": 0.58,
     "unit": "fraction of world population using safely managed sanitation services",
-    "year": 2022,
-    "source_name": "WHO/UNICEF Joint Monitoring Programme (JMP), Progress on household drinking water, sanitation and hygiene 2000-2022",
-    "source_url": "https://washdata.org/reports/jmp-2023-wash-households",
-    "note": "57% (about 4.5 billion people) had safely managed sanitation in 2022; 3.5 billion lacked it, of whom 419 million still practise open defecation. 'Safely managed' is the highest service rung (excreta safely treated/disposed), so the share with any basic toilet is higher."
+    "year": 2024,
+    "source_name": "WHO/UNICEF Joint Monitoring Programme (JMP), Progress on household drinking water, sanitation and hygiene 2000-2024 (2025 report)",
+    "source_url": "https://washdata.org/reports/jmp-2025-wash-households",
+    "note": "58% (about 4.8 billion people) had safely managed sanitation in 2024, up from 48% in 2015; 3.4 billion lacked it, of whom 354 million still practise open defecation. 'Safely managed' is the highest service rung (excreta safely treated/disposed), so the share with any basic toilet is higher."
   },
   "safely_managed_drinking_water_share":   {
-    "value": 0.73,
+    "value": 0.74,
     "unit": "fraction of world population using safely managed drinking-water services",
-    "year": 2022,
-    "source_name": "WHO/UNICEF Joint Monitoring Programme (JMP), Progress on household drinking water, sanitation and hygiene 2000-2022",
-    "source_url": "https://washdata.org/reports/jmp-2023-wash-households",
-    "note": "73% had safely managed drinking water in 2022; 2.2 billion lacked it, including 115 million who still drink untreated surface water. This is a service-access measure and is distinct from the renewable-freshwater resource volume entry, which shows the planet has ~5,000+ m3 of renewable freshwater per person per year."
+    "year": 2024,
+    "source_name": "WHO/UNICEF Joint Monitoring Programme (JMP), Progress on household drinking water, sanitation and hygiene 2000-2024 (2025 report)",
+    "source_url": "https://washdata.org/reports/jmp-2025-wash-households",
+    "note": "74% had safely managed drinking water in 2024, up from 68% in 2015; 2.1 billion lacked it, including 106 million who still drink untreated surface water. This is a service-access measure and is distinct from the renewable-freshwater resource volume entry, which shows the planet has ~5,000+ m3 of renewable freshwater per person per year."
   },
   "clean_cooking_polluting_fuel_people":   {
     "value": 2100000000,

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <meta property="og:image:alt" content="The world already produces enough. Food 1.4x, water 287x, electricity 3.9x, GDP 13x their respective minimum-need thresholds.">
 <meta property="og:site_name" content="Abundance">
 <meta property="article:published_time" content="2026-05-15T00:00:00Z">
-<meta property="article:modified_time" content="2026-07-26T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-13T00:00:00Z">
 
 <!-- Twitter / X -->
 <meta name="twitter:card" content="summary_large_image">
@@ -56,7 +56,7 @@
         "height": 630
       },
       "datePublished": "2026-05-15",
-      "dateModified": "2026-07-26",
+      "dateModified": "2026-08-13",
       "author": { "@type": "Person", "name": "Eli Vargas (lordbasilaiassistant-sudo)" },
       "publisher": {
         "@type": "Organization",
@@ -72,7 +72,7 @@
       "isAccessibleForFree": true,
       "url": "https://lordbasilaiassistant-sudo.github.io/Abundance/",
       "inLanguage": ["en", "es"],
-      "wordCount": 7400,
+      "wordCount": 8200,
       "articleSection": [
         "Per-capita arithmetic",
         "Money / UBI feasibility",
@@ -82,6 +82,7 @@
         "Redistribution calculator",
         "Historical context",
         "FAQ",
+        "Post-money enterprise",
         "Methodology and sources"
       ],
       "keywords": "abundance, scarcity, universal basic income, UBI, redistribution, per capita, world production, world GDP, hunger, poverty, Amartya Sen, Bengal famine, entitlement failure, Omelas, GiveDirectly, Alaska Permanent Fund, Bolsa Familia, cash transfer evidence",
@@ -257,7 +258,7 @@
 
 <header class="masthead">
   <div class="eyebrow">
-    A primary-sourced arithmetic · updated 2026-07-26
+    A primary-sourced arithmetic · updated 2026-08-13
     &nbsp;·&nbsp;
     <a href="lang/es/">Español</a>
     &nbsp;·&nbsp;
@@ -333,8 +334,9 @@
   <a href="#history">8 · Historical context — work as a recent system</a>
   <a href="#limits">9 · Honest limits of this page</a>
   <a href="#faq">10 · Common objections, answered</a>
-  <a href="#act">11 · What this asks of whoever can act</a>
-  <a href="#sources">12 · Sources &amp; methodology</a>
+  <a href="#beyond-money">11 · Beyond money — the post-money enterprise</a>
+  <a href="#act">12 · What this asks of whoever can act</a>
+  <a href="#sources">13 · Sources &amp; methodology</a>
 </nav>
 
 <div class="card tinted-warm" style="margin-bottom:24px">
@@ -1699,11 +1701,201 @@
 </section>
 
 <!-- ============================================================
-     SECTION 11 — What this asks of whoever can act
+     SECTION 11 — Beyond money / the post-money enterprise
+     Why money-maximisation is the mechanism behind §4's
+     manufactured scarcity, and cited real enterprises that
+     demote money from objective to constraint. Prose + .pilot
+     blocks mirroring §6. Numbers here are stable pre-2026 facts,
+     each with a source line.
+     ============================================================ -->
+<section id="beyond-money">
+<h2>11 · Beyond money — what a post-money enterprise is</h2>
+<p>
+  Every section above measures the same gap: the world produces enough, and
+  people still go without. <a href="#scarcity">Section 4</a> named the reason
+  the gap is defended — <em>manufactured scarcity</em>, the scarcity someone
+  profits from. This section names the mechanism behind it, and what it looks
+  like when the mechanism is switched off.
+</p>
+<p>
+  Money is a measuring instrument. It was invented so that strangers could
+  coordinate — so a sack of grain could be compared to an hour of labour to a
+  roof over a head. That is an extraordinary tool, and this page is not against
+  it (see <a href="#limits">§9</a>: money is a coordination technology, and
+  whether to keep it is a different question from whether the resources exist).
+</p>
+<p>
+  The problem is not money. The problem is treating <em>the reading on the
+  instrument</em> as the thing to maximise. Once "make the number go up" becomes
+  the objective function of an enterprise, abundance becomes a liability. If
+  insulin is cheap to make, the rational money-maximiser raises the price
+  (<a href="#card-insulin">§2</a>). If a song can be copied for free, the
+  rational money-maximiser builds a fence around it. If a phone could last ten
+  years, the rational money-maximiser designs it to last three. Under that
+  objective, scarcity is not a market failure — it is the product. Nearly
+  everything in <a href="#scarcity">§4</a> follows from one inverted priority:
+  the map was mistaken for the territory.
+</p>
+
+<div class="disclaim">
+  <p>
+    <strong>Post-money does not mean no money.</strong> It means money demoted
+    from master to tool — from the <em>objective</em> a business optimises to a
+    <em>constraint</em> it operates within. "Earn enough to keep going and do the
+    work" instead of "earn as much as is extractable." Profit becomes oxygen:
+    necessary to live, not the reason for living. That single change to the
+    objective function is enough to remove the incentive that manufactures
+    scarcity — and it is not a thought experiment. Enterprises already run this
+    way, some of them for a century, on ordinary shelves, against competitors
+    who don't.
+  </p>
+</div>
+
+<h3>These already exist, at scale</h3>
+
+<div class="pilot">
+  <h4>Patagonia — "Earth is now our only shareholder" (2022)</h4>
+  <div class="meta">Company valued ~$3B · ~$100M/yr in profit routed to the environment · permanently, by structure</div>
+  <p class="small">
+    In 2022 Yvon Chouinard and his family gave Patagonia away: all voting stock
+    to a purpose trust, all economic value to a non-profit (the Holdfast
+    Collective). The profit the company makes after reinvesting in itself — an
+    estimated $100 million a year — now leaves to fight the environmental crisis,
+    and the ownership structure makes any other use impossible.
+  </p>
+  <ul>
+    <li>The company still sells jackets and still makes money; it simply
+        <strong>cannot be sold, taken public, or cashed out</strong> for a
+        founder's exit.</li>
+    <li>Money is the fuel, not the destination — the clearest live example of an
+        objective function set to something other than accumulation.</li>
+  </ul>
+  <p class="src">
+    Source: <a href="https://www.patagonia.com/ownership/">Patagonia, "Earth is now our only shareholder"</a>
+  </p>
+</div>
+
+<div class="pilot">
+  <h4>The $1 patent — insulin (1923) and Salk's sun (1955)</h4>
+  <div class="meta">Two of the most valuable inventions of the 20th century · deliberately un-owned</div>
+  <p class="small">
+    In 1923 the discoverers of insulin sold the patent to the University of
+    Toronto for $1 so that no one could monopolise a molecule that keeps people
+    alive. In 1955, asked who owned the patent on his polio vaccine, Jonas Salk
+    answered: "The people, I would say. There is no patent. Could you patent the
+    sun?"
+  </p>
+  <ul>
+    <li>Both inventions were worth staggering fortunes; both inventors decided
+        the value of the thing was that <strong>everyone could have it</strong>.</li>
+    <li>Insulin's later journey to a ~$90 US pen (<a href="#card-insulin">§2</a>)
+        is what happens when that decision is reversed — the same molecule, a
+        different objective function.</li>
+  </ul>
+  <p class="src">
+    Sources:
+    <a href="https://insulin.library.utoronto.ca/">University of Toronto, Insulin Collection</a> ·
+    <a href="https://retroreport.org/video/could-you-patent-the-sun/">Salk, <em>See It Now</em> interview (CBS, 12 April 1955), Retro Report archival footage</a>
+  </p>
+</div>
+
+<div class="pilot">
+  <h4>The commons the economy runs on — Linux &amp; Wikipedia</h4>
+  <div class="meta">100% of the world's 500 fastest supercomputers · most web servers · every Android phone · a top global website with no ads</div>
+  <p class="small">
+    Linux — written by thousands of paid and volunteer engineers and given away
+    under a licence that forbids anyone from making it exclusive — runs every one
+    of the world's 500 fastest supercomputers, most of the servers behind the
+    internet, and the kernel inside every Android phone. Wikipedia, run by a
+    non-profit with no advertising, is among the most-visited websites on Earth.
+  </p>
+  <ul>
+    <li>These are not charities losing to the "real" economy; they are
+        <strong>load-bearing infrastructure the for-profit economy is built on
+        top of</strong>.</li>
+    <li>Produced by people whose objective was the work and the commons, not the
+        price.</li>
+  </ul>
+  <p class="src">
+    Sources:
+    <a href="https://www.top500.org/statistics/details/osfam/1/">TOP500 operating-system share</a> ·
+    <a href="https://wikimediafoundation.org/">Wikimedia Foundation</a>
+  </p>
+</div>
+
+<div class="pilot">
+  <h4>100% out the door — Newman's Own (1982–present)</h4>
+  <div class="meta">&gt;$600M given away to date · 100% of profits and royalties · sold at ordinary supermarket prices</div>
+  <p class="small">
+    Paul Newman started a food company in 1982 and gave away all of it. Newman's
+    Own donates 100% of its profits and royalties to charity — more than
+    $600 million to date — while competing on ordinary shelves against companies
+    that keep theirs.
+  </p>
+  <ul>
+    <li>It sells salad dressing at a normal price and routes the
+        <strong>entire margin</strong> to people who need it.</li>
+    <li>Profitability and private accumulation turn out to be separable — you can
+        keep one and give away the other.</li>
+  </ul>
+  <p class="src">
+    Source: <a href="https://newmansown.org/faq/">Newman's Own Foundation</a> ·
+    <a href="https://www.prnewswire.com/news-releases/600-million-in-giving-surpassed-on-40th-anniversary-of-newmans-own-the-pioneering-purpose-driven-brand-301698279.html">$600M-in-giving milestone (2022)</a>
+  </p>
+</div>
+
+<div class="pilot">
+  <h4>Proof it doesn't need an owner — Ostrom's commons (2009 Nobel)</h4>
+  <div class="meta">Irrigation systems, fisheries, forests, pastures across several continents · centuries of working examples</div>
+  <p class="small">
+    Elinor Ostrom won the 2009 Nobel in economics for documenting that
+    communities manage shared resources sustainably for generations without
+    privatising them and without a state running them — directly refuting the
+    "tragedy of the commons" assumption that only ownership or coercion prevents
+    ruin.
+  </p>
+  <ul>
+    <li>The commons is <strong>not a naive dream that has never been tried</strong>.
+        It is a governance form with documented, durable, real-world cases and a
+        Nobel behind it.</li>
+  </ul>
+  <p class="src">
+    Source: <a href="https://www.nobelprize.org/prizes/economic-sciences/2009/ostrom/facts/">Ostrom, 2009 Sveriges Riksbank Prize</a> ·
+    Ostrom (1990), <em>Governing the Commons</em>, Cambridge University Press.
+  </p>
+</div>
+
+<h3>Why this is the important part</h3>
+<p>
+  You can accept every number on this page and still feel the shortfalls are
+  inevitable — because the instrument you use to think about them is built to see
+  scarcity. A ledger cannot record "enough." It records only more and less, mine
+  and not-mine, priced and unpriced. Ask a money-maximiser to distribute an
+  abundance and you are asking it to dissolve its own reason to exist — which is
+  why it won't, and why <a href="#money">"we can't afford it"</a> keeps feeling
+  true from inside the ledger even when the granaries are full.
+</p>
+<p>
+  Stepping outside that frame is not utopian, and it is not the abolition of
+  markets. It is the ordinary, already-proven move of putting the objective back
+  where it belongs: human need met, work done well — the thing money was only
+  ever supposed to be a proxy for. The enterprises above did nothing exotic. They
+  demoted the number. This site is one more small instance of the same move —
+  public domain (CC0), no ads, no tracking, with free
+  <a href="tools/">in-browser tools</a> and a public
+  <a href="https://graveyard.broke2builtai.com">graveyard</a> of its own dead
+  projects, given away for parts. Manufactured scarcity is a choice. So is the
+  alternative — and it is already sitting on the shelf, next to the salad
+  dressing.
+</p>
+</section>
+
+<!-- ============================================================
+     SECTION 12 — What this asks of whoever can act
      The turn to the reader. Full version: letter.html
      ============================================================ -->
 <section id="act">
-<h2>11 · What this asks of whoever can act</h2>
+<h2>12 · What this asks of whoever can act</h2>
 <p>
   Everything above is one argument: the world already produces enough, so the
   shortfalls are distribution, and distribution is a choice. That leaves one
@@ -1748,7 +1940,7 @@
      Pointers to data/*.json, methodology.md, bibliography.md.
      ============================================================ -->
 <section id="sources">
-<h2>12 · Sources &amp; methodology</h2>
+<h2>13 · Sources &amp; methodology</h2>
 <p>
   All raw values live in
   <a href="data/essentials.json"><code>data/essentials.json</code></a>,

--- a/index.html
+++ b/index.html
@@ -711,21 +711,21 @@
 <div class="card" id="card-sanitation">
   <h3>Sanitation <span class="tag uneven">distribution failure</span></h3>
   <div class="row">
-    <div class="stat"><div class="label">World population with safely managed sanitation</div><div class="value accent" id="sanitation-have">57%</div><div class="sub">WHO/UNICEF JMP (2023)</div></div>
-    <div class="stat"><div class="label">People still lacking it</div><div class="value danger" id="sanitation-lack">3.5 billion</div><div class="sub">WHO/UNICEF JMP (2023)</div></div>
+    <div class="stat"><div class="label">World population with safely managed sanitation</div><div class="value accent" id="sanitation-have">58%</div><div class="sub">WHO/UNICEF JMP (2025)</div></div>
+    <div class="stat"><div class="label">People still lacking it</div><div class="value danger" id="sanitation-lack">3.4 billion</div><div class="sub">WHO/UNICEF JMP (2025)</div></div>
   </div>
-  <p>The engineering of safe sanitation is a solved problem and most of the world already lives with it: in 2022 some <span class="num">57%</span> of humanity (about <span class="num">4.5 billion</span> people) used safely managed sanitation. The remaining <span class="num">3.5 billion</span> without it, including <span class="num">419 million</span> who still practise open defecation, are short of plumbing and treatment capacity, not of any unknown technology. This is a distribution and investment gap, not a production limit.</p>
-  <p class="src">Source: <a href="https://washdata.org/reports/jmp-2023-wash-households">WHO/UNICEF Joint Monitoring Programme (2023). Progress on household drinking water, sanitation and hygiene 2000-2022.</a></p>
+  <p>The engineering of safe sanitation is a solved problem and most of the world already lives with it: in 2024 some <span class="num">58%</span> of humanity (about <span class="num">4.8 billion</span> people) used safely managed sanitation, up from 48% in 2015. The remaining <span class="num">3.4 billion</span> without it, including <span class="num">354 million</span> who still practise open defecation, are short of plumbing and treatment capacity, not of any unknown technology. This is a distribution and investment gap, not a production limit.</p>
+  <p class="src">Source: <a href="https://washdata.org/reports/jmp-2025-wash-households">WHO/UNICEF Joint Monitoring Programme (2025). Progress on household drinking water, sanitation and hygiene 2000-2024.</a></p>
 </div>
 
 <div class="card" id="card-drinking-water">
   <h3>Drinking-water access <span class="tag uneven">distribution failure</span></h3>
   <div class="row">
-    <div class="stat"><div class="label">World population with safely managed drinking water</div><div class="value accent" id="water-access-have">73%</div><div class="sub">WHO/UNICEF JMP (2023)</div></div>
-    <div class="stat"><div class="label">People still lacking it</div><div class="value danger" id="water-access-lack">2.2 billion</div><div class="sub">WHO/UNICEF JMP (2023)</div></div>
+    <div class="stat"><div class="label">World population with safely managed drinking water</div><div class="value accent" id="water-access-have">74%</div><div class="sub">WHO/UNICEF JMP (2025)</div></div>
+    <div class="stat"><div class="label">People still lacking it</div><div class="value danger" id="water-access-lack">2.1 billion</div><div class="sub">WHO/UNICEF JMP (2025)</div></div>
   </div>
-  <p>The planet's renewable freshwater works out to thousands of cubic metres per person per year; the binding constraint is delivery, not the resource. In 2022 some <span class="num">73%</span> of humanity used safely managed drinking water, while <span class="num">2.2 billion</span> people did not, including <span class="num">115 million</span> who still drink untreated surface water. The water exists and treatment is routine engineering; the gap is pipes, pumps and treatment plants where they have not been built.</p>
-  <p class="src">Source: <a href="https://washdata.org/reports/jmp-2023-wash-households">WHO/UNICEF Joint Monitoring Programme (2023). Progress on household drinking water, sanitation and hygiene 2000-2022.</a></p>
+  <p>The planet's renewable freshwater works out to thousands of cubic metres per person per year; the binding constraint is delivery, not the resource. In 2024 some <span class="num">74%</span> of humanity used safely managed drinking water (up from 68% in 2015), while <span class="num">2.1 billion</span> people did not, including <span class="num">106 million</span> who still drink untreated surface water. The water exists and treatment is routine engineering; the gap is pipes, pumps and treatment plants where they have not been built.</p>
+  <p class="src">Source: <a href="https://washdata.org/reports/jmp-2025-wash-households">WHO/UNICEF Joint Monitoring Programme (2025). Progress on household drinking water, sanitation and hygiene 2000-2024.</a></p>
 </div>
 
 <div class="card" id="card-clean-cooking">


### PR DESCRIPTION
## What this does

Two things: (1) add a new main-page section making the case for post-money thinking, and (2) fact-check the page's figures and refresh what's genuinely stale.

### 1 · New §11 — "Beyond money — what a post-money enterprise is"
Argues, in the site's cited style, that money-maximisation is the *mechanism* behind §4's manufactured scarcity — and shows real enterprises that demote money from objective to constraint: Patagonia's 2022 steward-ownership transfer, the $1 insulin patent + Salk's polio vaccine, the Linux/Wikipedia commons, Newman's Own (100% of profit to charity), and Ostrom's 2009 Nobel on the commons. A `.disclaim` callout keeps the scope honest (*post-money ≠ no money*), consistent with §9.

Renumbers former §11 (call-to-action) → §12 and §12 (sources) → §13; updates TOC, JSON-LD `articleSection`/`wordCount`, `dateModified`, and the eyebrow date. No prose cross-references pointed at the renumbered sections. New-section citations verified live (Retro Report for Salk; newmansown.org).

### 2 · Fact-check + data refresh
Every headline figure was checked against its cited **2026 primary source** (IMF WEO April 2026, Energy Institute/Ember 2026, FAO CSDB, SOFI 2026, SIPRI April 2026, ITU 2025, World Bank March 2026, UN WPP 2024). **No hard-wrong figures.**

Refreshed the one clearly-updatable dataset — **WHO/UNICEF JMP 2023 (2022 data) → JMP 2025 (2024 data)**, confirmed against WHO/UNICEF primary sources, in both `index.html` and `data/essentials.json`:
- Safely managed drinking water: 73% → **74%**; 2.2B → **2.1B** lacking; surface-water drinkers 115M → **106M**.
- Safely managed sanitation: 57% → **58%**; 3.5B → **3.4B** lacking; open defecation 419M → **354M**.

**Deliberately not changed:** global household wealth ($449.9T, 2023 / UBS GWR 2024). UBS's GWR 2026 publishes only growth rates (+10.8% in 2025), not a citeable aggregate — updating it would need the extrapolation the project's sourcing rules forbid. README already documents this; refresh date bumped.

### Files changed
- `index.html`, `data/essentials.json`, `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)